### PR TITLE
feat: add new signal for docking

### DIFF
--- a/msg/SignalStatus.msg
+++ b/msg/SignalStatus.msg
@@ -16,6 +16,8 @@ string SIGNAL_RAISING_ELEVATOR=raising_elevator
 string SIGNAL_LOWERING_ELEVATOR=lowering_elevator
 string SIGNAL_LOCALIZATION_ERROR=localization_error
 string SIGNAL_LOCALIZATION_NOT_RELIABLE=localization_not_reliable
+string SIGNAL_ROBOT_DOCKING=dock_to_charge
+
 
 string node_name
 string[] active_signals

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>robotnik_signal_msgs</name>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
   <description>The robotnik_signal_msgs package</description>
 
   <maintainer email="aarnal@robotnik.es">Alejandro Arnal</maintainer>


### PR DESCRIPTION
This pull request adds a new signal status to the `SignalStatus.msg` message definition. The main change is the introduction of a constant for robot docking status.

New signal addition:

* Added `SIGNAL_ROBOT_DOCKING` constant with the value `dock_to_charge` to indicate when the robot is docking to charge.